### PR TITLE
VIAF suggestion function fix

### DIFF
--- a/src/script.py
+++ b/src/script.py
@@ -326,8 +326,10 @@ for use_page_number in range(1,50):
 			if viaf_id != False:	
 				viaf_links={}
 				viaf_xml = ""
+				viaf_url = "https://viaf.org/viaf/" + viaf_id
+				viaf_headers = {"user-agent":'LCNNBot/1.0 (https://www.wikidata.org/wiki/User:LCNNBot)', "Accept": 'application/xml'}
 				try:
-					viaf_req = requests.get(f"https://viaf.org/viaf/{viaf_id}/viaf.xml",headers=headers)
+					viaf_req = requests.get(viaf_url,headers=viaf_headers)
 					viaf_xml = viaf_req.text
 					viaf_xml = viaf_xml.replace(">",">\n")
 				except:

--- a/src/script.py
+++ b/src/script.py
@@ -327,7 +327,7 @@ for use_page_number in range(1,50):
 				viaf_links={}
 				viaf_xml = ""
 				viaf_url = "https://viaf.org/viaf/" + viaf_id
-				viaf_headers = {"user-agent":'LCNNBot/1.0 (https://www.wikidata.org/wiki/User:LCNNBot)', "Accept": 'application/xml'}
+				viaf_headers = {"user-agent":'LCNNBot/1.0 (https://www.wikidata.org/wiki/User:LCNNBot)', "Accept":'application/xml'}
 				try:
 					viaf_req = requests.get(viaf_url,headers=viaf_headers)
 					viaf_xml = viaf_req.text


### PR DESCRIPTION
As discussed [here](https://www.wikidata.org/wiki/User_talk:Bargioni/moreIdentifiers#New_VIAF_interface), the VIAF API no longer accepts requests ending in .json, .xml, etc. and instead an Accept header is required to retrieve data in a specific format. The code has been revised to call the API with a header requesting the data in xml format. This retrieves the data in the format required for the rest of the VIAF suggestion function to work.